### PR TITLE
fix: update git clone command to be anonymous

### DIFF
--- a/codelab.md
+++ b/codelab.md
@@ -209,7 +209,7 @@ To begin this codelab, begin by cloning the repository *at* the initial version,
 ```bash
 mkdir ~/codelab
 cd ~/codelab
-git clone --branch v1.0 git@github.com:microsoft-healthcare-madison/demo-auc-app.git
+git clone --branch v1.0 https://github.com/microsoft-healthcare-madison/demo-auc-app.git
 cd demo-auc-app
 npm install
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -171,7 +171,7 @@
 <p>To begin this codelab, begin by cloning the repository <em>at</em> the initial version, which is <code>v1.0</code>.</p>
 <pre><code>mkdir ~/codelab
 cd ~/codelab
-git clone --branch v1.0 git@github.com:microsoft-healthcare-madison/demo-auc-app.git
+git clone --branch v1.0 https://github.com/microsoft-healthcare-madison/demo-auc-app.git
 cd demo-auc-app
 npm install
 </code></pre>


### PR DESCRIPTION
for users who don't have an ssh key associated with their github account already, the clone command fails.  This change will be friendlier to users who are new to github.